### PR TITLE
Fix behavior of setSelected in "single" selectMode

### DIFF
--- a/src/wb_node.ts
+++ b/src/wb_node.ts
@@ -2573,9 +2573,11 @@ export class WunderbaumNode {
         this.selected = flag;
         if (selectMode === "hier") {
           this.fixSelection3AfterClick();
-        } else if (selectMode === "single") {
+        } else if (selectMode === "single" && flag) {
           tree.visit((n) => {
-            n.selected = false;
+            if (n !== this) {
+              n.selected = false;
+            }
           });
         }
       }


### PR DESCRIPTION
Fixed two behavioral issues:

1. In "single" selectMode, `setSelected(true)` would end up immediately resetting a selected node, because the `visit` would unconditionally reset all nodes.

2. The resetting was also done in the case of `setSelected(false)`. This struck me as undesirable behavior, although that's certainly more debatable.

Let me know if this is acceptable, or whether I should back out fix 2 (my own code does not depend on it). 