### PR TITLE
Restore ability to edit with double click

### DIFF
--- a/src/wunderbaum.ts
+++ b/src/wunderbaum.ts
@@ -534,7 +534,6 @@ export class Wunderbaum {
           } else {
             node.setActive(true, { event: e });
           }
-          node.setFocus();
         }
       }
       this.lastClickTime = Date.now();


### PR DESCRIPTION
Commit 73fff08e2b2112ba7246fd5304084faff9bd86e3 appears to have broken the functionality of editing a title with a double click (F2 and Enter still work).

This PR restores this functionality by removing the extra `setFocus()` added in 73fff08e2b2112ba7246fd5304084faff9bd86e3; I'm not sure what further repercussions this has — I did not see anything broken, but I don't understand the focusing in sufficient detail to be sure this is a safe fix.